### PR TITLE
update/base-url-api

### DIFF
--- a/src/Constant.php
+++ b/src/Constant.php
@@ -24,5 +24,5 @@ class Constant
     /**
      * Base URL for production mode
      */
-    public const URL_PRODUCTION = 'https://gateway-prod-a2.linkqu.id';
+    public const URL_PRODUCTION = 'https://api.linkqu.id';
 }


### PR DESCRIPTION
Starting May 1, 2025, the production urls replaced by https://api.linkqu.id/